### PR TITLE
Update types.py

### DIFF
--- a/wagtail_localize/segments/types.py
+++ b/wagtail_localize/segments/types.py
@@ -84,7 +84,7 @@ class StringSegmentValue(BaseValue):
             string = StringValue.from_plaintext(string)
 
         elif string is None:
-            pass
+            string = ""
 
         elif isinstance(string, StringValue):
             pass

--- a/wagtail_localize/segments/types.py
+++ b/wagtail_localize/segments/types.py
@@ -83,6 +83,9 @@ class StringSegmentValue(BaseValue):
         if isinstance(string, str):
             string = StringValue.from_plaintext(string)
 
+        elif string is None:
+            pass
+
         elif isinstance(string, StringValue):
             pass
 


### PR DESCRIPTION
Allow string values to be None. String blocks can not exist on struct blocks if a block field has been added in a migration but not filled.

On trying to synchronise a tree of pages from the base language to a translation we ran into a error
```
TypeError `string` must be either a `StringValue` or a `str`. Got `NoneType`
```

This came from a custom struct block with a `TextBlock` registered, but the json content in the database had no value for it in the content for one of the pages in the tree. This particular field on the struct block had been added in a recent code change, resulting in no value in the content for all pages, until an editor saves it.

This change should allow the sync to complete.