### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ With your preferred virtualenv activated, install testing dependencies:
 
 ```sh
 pip install pip>=21.3
-pip install -e .[testing] -U
+pip install -e '.[testing]' -U
 ```
 
 #### Using flit


### PR DESCRIPTION
Running `pip install -e .[testing] -U` gave me `zsh: no matches found: .[testing]`

Flit worked, but wrapping in `.[testing]` in quotes worked too.